### PR TITLE
Add demo Next.js frontend and Node backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,31 @@
-# DemoCodeX
+# DemoCodeX Website
+
+This repository demonstrates a simple web app with a Next.js frontend and a Node.js backend using Express.
+
+## Getting Started
+
+1. Install dependencies for both `frontend` and `backend`:
+
+```bash
+cd frontend
+npm install
+cd ../backend
+npm install
+```
+
+2. Start the backend server:
+
+```bash
+npm start
+```
+
+3. In a new terminal, start the Next.js development server:
+
+```bash
+cd frontend
+npm run dev
+```
+
+Visit `http://localhost:3000` in your browser.
+
+The backend API documentation is available at `http://localhost:4000/api-docs`.

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "demo-backend",
+  "version": "1.0.0",
+  "main": "server.js",
+  "license": "MIT",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "swagger-ui-express": "^4.6.3"
+  }
+}

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,0 +1,16 @@
+const express = require('express');
+const swaggerUi = require('swagger-ui-express');
+const app = express();
+const port = 4000;
+
+const swaggerDocument = require('./swagger.json');
+
+app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerDocument));
+
+app.get('/api/hello', (req, res) => {
+  res.json({ message: 'Hello from the backend!' });
+});
+
+app.listen(port, () => {
+  console.log(`Backend listening at http://localhost:${port}`);
+});

--- a/backend/swagger.json
+++ b/backend/swagger.json
@@ -1,0 +1,31 @@
+{
+  "openapi": "3.0.0",
+  "info": {
+    "title": "Demo API",
+    "version": "1.0.0"
+  },
+  "paths": {
+    "/api/hello": {
+      "get": {
+        "summary": "Say hello",
+        "responses": {
+          "200": {
+            "description": "A greeting message",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "message": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "demo-frontend",
+  "version": "1.0.0",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "^14.2.4",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  }
+}

--- a/frontend/pages/index.js
+++ b/frontend/pages/index.js
@@ -1,0 +1,19 @@
+import { useEffect, useState } from 'react';
+
+export default function Home() {
+  const [message, setMessage] = useState('');
+
+  useEffect(() => {
+    fetch('http://localhost:4000/api/hello')
+      .then(res => res.json())
+      .then(data => setMessage(data.message))
+      .catch(err => console.error(err));
+  }, []);
+
+  return (
+    <div>
+      <h1>Next.js Frontend</h1>
+      <p>{message}</p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add frontend built with Next.js
- add backend Express server with Swagger UI
- update README with setup instructions

## Testing
- `node backend/server.js` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_685259b49b0c8332a71d675e058d94e7